### PR TITLE
Let datachannel (DCEP) close the outgoing stream on receipt of EOF

### DIFF
--- a/association.go
+++ b/association.go
@@ -1985,6 +1985,7 @@ func (a *Association) sendResetRequest(streamIdentifier uint16) error {
 func (a *Association) handleReconfigParam(raw param) (*packet, error) {
 	switch p := raw.(type) {
 	case *paramOutgoingResetRequest:
+		a.log.Tracef("[%s] handleReconfigParam (OutgoingResetRequest)", a.name)
 		a.reconfigRequests[p.reconfigRequestSequenceNumber] = p
 		resp := a.resetStreamsIfAny(p)
 		if resp != nil {
@@ -1993,6 +1994,7 @@ func (a *Association) handleReconfigParam(raw param) (*packet, error) {
 		return nil, nil //nolint:nilnil
 
 	case *paramReconfigResponse:
+		a.log.Tracef("[%s] handleReconfigParam (ReconfigResponse)", a.name)
 		delete(a.reconfigs, p.reconfigResponseSequenceNumber)
 		if len(a.reconfigs) == 0 {
 			a.tReconfig.stop()

--- a/association.go
+++ b/association.go
@@ -2017,7 +2017,8 @@ func (a *Association) resetStreamsIfAny(p *paramOutgoingResetRequest) *packet {
 			a.lock.Unlock()
 			s.onInboundStreamReset()
 			a.lock.Lock()
-			a.unregisterStream(s, io.EOF)
+			a.log.Debugf("[%s] deleting stream %d", a.name, id)
+			delete(a.streams, s.streamIdentifier)
 		}
 		delete(a.reconfigRequests, p.reconfigRequestSequenceNumber)
 	} else {

--- a/stream.go
+++ b/stream.go
@@ -392,3 +392,9 @@ func (s *Stream) onInboundStreamReset() {
 		s.state = StreamStateClosed
 	}
 }
+
+func (s *Stream) State() StreamState {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.state
+}


### PR DESCRIPTION
Hi @jerry-tao 

I cleaned up the code a bit to let datachannel close the outgoing stream on receipt of EOF.

The change is based on this [pion/sctp: State Transition](https://docs.google.com/spreadsheets/d/1sgQkvrL90vXiPEjJFECtgd95rukQL78z259bJLZE1RY/edit#gid=0) I had in mind.

My test case (pion-server) works with this code. I haven't tried your code yet.
I think we need a unit test to verify this state transition. I can work on it once this is confirmed work with your tests cases.